### PR TITLE
Fix lessons query variable names

### DIFF
--- a/src/hooks/useLessons.ts
+++ b/src/hooks/useLessons.ts
@@ -38,13 +38,13 @@ export const useLessons = (moduleId: string) => {
         .eq('module_id', moduleId)
         .order('order_index', { ascending: true });
 
-      if (error) {
-        console.error('Error fetching lessons:', error);
-        throw error;
+      if (lessonsError) {
+        console.error('Error fetching lessons:', lessonsError);
+        throw lessonsError;
       }
-      
-      console.log('Lessons fetched successfully:', data?.length);
-      return data as Lesson[];
+
+      console.log('Lessons fetched successfully:', lessons?.length);
+      return lessons as Lesson[];
     },
     enabled: !!moduleId && !!user,
   });


### PR DESCRIPTION
## Summary
- update `useLessons` query to use lessonsError and lessons variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68739752d494832db1d8a9041973a3cb