### PR TITLE
Update progress gating with quiz props

### DIFF
--- a/src/components/student/LessonProgress.tsx
+++ b/src/components/student/LessonProgress.tsx
@@ -11,9 +11,11 @@ interface LessonProgressProps {
   currentLesson: StudentLesson;
   watchTime: number;
   duration: number;
+  hasQuiz: boolean;
+  quizPassed?: boolean;
 }
 
-export const LessonProgress = ({ currentLesson, watchTime, duration }: LessonProgressProps) => {
+export const LessonProgress = ({ currentLesson, watchTime, duration, hasQuiz, quizPassed }: LessonProgressProps) => {
   const { user } = useAuth();
   const { mutate: updateProgress, resetCompletionToasts } = useSimplifiedLessonProgress();
   
@@ -34,13 +36,14 @@ export const LessonProgress = ({ currentLesson, watchTime, duration }: LessonPro
   // Auto-complete lesson when 95% is watched (only once)
   useEffect(() => {
     if (
-      currentLesson && 
+      currentLesson &&
       user?.id &&
-      !currentLesson.completed && 
+      !currentLesson.completed &&
       !autoCompletedRef.current &&
-      duration > 0 && 
+      duration > 0 &&
       progressPercentage >= 95 &&
-      progressPercentage > lastProgressPercentageRef.current
+      progressPercentage > lastProgressPercentageRef.current &&
+      (!hasQuiz || quizPassed)
     ) {
       console.log('🎯 Auto-completing lesson at 95% progress');
       autoCompletedRef.current = true;
@@ -53,7 +56,7 @@ export const LessonProgress = ({ currentLesson, watchTime, duration }: LessonPro
     }
     
     lastProgressPercentageRef.current = progressPercentage;
-  }, [currentLesson, progressPercentage, duration, watchTime, updateProgress, user?.id]);
+  }, [currentLesson, progressPercentage, duration, watchTime, updateProgress, user?.id, hasQuiz, quizPassed]);
 
   // Periodic save with better timing
   useEffect(() => {

--- a/src/components/student/lesson/LessonSidebar.tsx
+++ b/src/components/student/lesson/LessonSidebar.tsx
@@ -9,6 +9,8 @@ interface LessonSidebarProps {
   courseId: string;
   watchTime: number;
   duration: number;
+  hasQuiz: boolean;
+  quizPassed?: boolean;
   prevLesson?: { id: string; title: string };
   nextLesson?: { id: string; title: string };
   nextLessonBlocked?: boolean;
@@ -19,9 +21,11 @@ interface LessonSidebarProps {
 export const LessonSidebar = ({ 
   currentLesson, 
   courseId, 
-  watchTime, 
-  duration, 
-  prevLesson, 
+  watchTime,
+  duration,
+  hasQuiz,
+  quizPassed,
+  prevLesson,
   nextLesson,
   nextLessonBlocked,
   nextLessonBlockedReason,
@@ -35,10 +39,12 @@ export const LessonSidebar = ({
           <CardTitle className="text-base sm:text-lg font-semibold">Progresso</CardTitle>
         </CardHeader>
         <CardContent className="pt-4 px-4 sm:px-6 pb-4 sm:pb-6">
-          <LessonProgress 
+          <LessonProgress
             currentLesson={currentLesson}
             watchTime={watchTime}
             duration={duration}
+            hasQuiz={hasQuiz}
+            quizPassed={quizPassed}
           />
         </CardContent>
       </Card>

--- a/src/components/student/lesson/LessonViewContent.tsx
+++ b/src/components/student/lesson/LessonViewContent.tsx
@@ -88,6 +88,7 @@ export const LessonViewContent = ({
   // Progresso do vídeo
   const progressPercentage = duration > 0 ? (watchTime / duration) * 100 : 0;
   const quizEnabled = progressPercentage >= 95;
+  const hasQuiz = !!quiz;
   const quizPassed = lastAttempt?.passed;
   const quizScore = lastAttempt?.score || 0;
 
@@ -250,6 +251,8 @@ export const LessonViewContent = ({
               courseId={courseId}
               watchTime={watchTime}
               duration={duration}
+              hasQuiz={hasQuiz}
+              quizPassed={quizPassed}
               prevLesson={prevLesson}
               nextLesson={nextLesson}
               nextLessonBlocked={nextLessonBlocked}
@@ -342,6 +345,8 @@ export const LessonViewContent = ({
                 courseId={courseId}
                 watchTime={watchTime}
                 duration={duration}
+                hasQuiz={hasQuiz}
+                quizPassed={quizPassed}
                 prevLesson={prevLesson}
                 nextLesson={nextLesson}
                 nextLessonBlocked={nextLessonBlocked}


### PR DESCRIPTION
## Summary
- allow `LessonProgress` to receive information about quizzes
- gate auto complete call based on quiz status
- forward `hasQuiz` and `quizPassed` through `LessonSidebar` and `LessonViewContent`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68739760fc3c832da13ff15dbf3608d4