### PR TITLE
Fix sequential lesson blocking

### DIFF
--- a/src/pages/StudentCourseDetail.tsx
+++ b/src/pages/StudentCourseDetail.tsx
@@ -174,12 +174,14 @@ const StudentCourseDetail = () => {
     if (!quizzesByLesson[quiz.lesson_id]) quizzesByLesson[quiz.lesson_id] = [];
     quizzesByLesson[quiz.lesson_id].push(quiz);
   });
-  const attemptsByLesson: Record<string, any[]> = {};
+  const attemptsByLesson: Record<string, any | null> = {};
   allAttempts.forEach((attempt: any) => {
     const quiz = allQuizzes.find((q: any) => q.id === attempt.quiz_id);
     if (quiz && quiz.lesson_id) {
-      if (!attemptsByLesson[quiz.lesson_id]) attemptsByLesson[quiz.lesson_id] = [];
-      attemptsByLesson[quiz.lesson_id].push(attempt);
+      const current = attemptsByLesson[quiz.lesson_id];
+      if (!current || attempt.attempt_number > current.attempt_number) {
+        attemptsByLesson[quiz.lesson_id] = attempt;
+      }
     }
   });
 
@@ -326,8 +328,8 @@ const StudentCourseDetail = () => {
                             prevCompleted = prevProgress?.completed || false;
                             const prevQuiz = quizzesByLesson[prevLesson.id];
                             const prevAttempt = attemptsByLesson[prevLesson.id];
-                            prevQuizPassed = prevQuiz ? prevAttempt?.passed : true;
-                            isBlocked = !(prevCompleted && prevQuizPassed);
+                            prevQuizPassed = prevQuiz && prevQuiz.length > 0 ? (prevAttempt?.passed ?? false) : true;
+                            isBlocked = !prevCompleted || !prevQuizPassed;
                           }
                         }
                         // LOG DE DEPURAÇÃO


### PR DESCRIPTION
## Summary
- fix lookup of last quiz attempt per lesson
- block a lesson if the previous lesson is incomplete or its quiz hasn't been passed

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68739761f8f0832d929c0f9a5df1a942